### PR TITLE
Open syscall

### DIFF
--- a/kern/arch/mips/syscall/syscall.c
+++ b/kern/arch/mips/syscall/syscall.c
@@ -110,6 +110,11 @@ syscall(struct trapframe *tf)
 		break;
 
 	    /* Add stuff here */
+		case SYS_open:
+		err = sys_open((userptr_t)tf->tf_a0,
+				(int) tf->tf_a1,
+				&retval);
+		break;
 
 	    default:
 		kprintf("Unknown syscall %d\n", callno);

--- a/kern/conf/conf.kern
+++ b/kern/conf/conf.kern
@@ -413,6 +413,7 @@ optfile   sfs    fs/sfs/sfs_fsops.c
 optfile   sfs    fs/sfs/sfs_inode.c
 optfile   sfs    fs/sfs/sfs_io.c
 optfile   sfs    fs/sfs/sfs_vnops.c
+optfile   sfs    fs/filetable.c
 
 #
 # netfs (the networked filesystem - you might write this as one assignment)

--- a/kern/conf/conf.kern
+++ b/kern/conf/conf.kern
@@ -379,6 +379,7 @@ file      vfs/devnull.c
 file      syscall/loadelf.c
 file      syscall/runprogram.c
 file      syscall/time_syscalls.c
+file      syscall/files_syscalls.c
 
 #
 # Startup and initialization

--- a/kern/fs/filetable.c
+++ b/kern/fs/filetable.c
@@ -27,29 +27,6 @@
  * SUCH DAMAGE.
  */
 
-
-/*
- * Code to load an ELF-format executable into the current address space.
- *
- * It makes the following address space calls:
- *    - first, as_define_region once for each segment of the program;
- *    - then, as_prepare_load;
- *    - then it loads each chunk of the program;
- *    - finally, as_complete_load.
- *
- * This gives the VM code enough flexibility to deal with even grossly
- * mis-linked executables if that proves desirable. Under normal
- * circumstances, as_prepare_load and as_complete_load probably don't
- * need to do anything.
- *
- * If you wanted to support memory-mapped executables you would need
- * to rearrange this to map each segment.
- *
- * To support dynamically linked executables with shared libraries
- * you'd need to change this to load the "ELF interpreter" (dynamic
- * linker). And you'd have to write a dynamic linker...
- */
-
 #include <fs.h>
 #include <kern/errno.h>
 #include <lib.h>
@@ -72,7 +49,7 @@ filetable_init(void)
 * The new file gets appended and the pointer is moved so that it always points
 * to the youngest/newest element.
 */
-int
+void
 filetable_addfile(struct fs_file *newfile)
 {
     if (sys_filetable == NULL) {
@@ -85,9 +62,6 @@ filetable_addfile(struct fs_file *newfile)
     }
     sys_filetable = newfile;
     sys_filetable_size++;
-
-    // exit successfully
-    return 0;
 }
 
 /*

--- a/kern/fs/filetable.c
+++ b/kern/fs/filetable.c
@@ -1,0 +1,13 @@
+#include <fs.h>
+
+struct fs_filetable sys_filetable;
+
+void
+filetable_init(void)
+{
+}
+
+void
+filetable_addfile(void)
+{
+}

--- a/kern/include/fs.h
+++ b/kern/include/fs.h
@@ -103,14 +103,14 @@ struct fs_file {
 */
 struct fs_filetable {
 	struct fs_file current;
-	struct fs_file *prev;
-	struct fs_file *next;
+	struct fs_filetable *prev;
+	struct fs_filetable *next;
 };
 
-extern struct fs_filetable sys_filetable;
+extern struct fs_filetable *sys_filetable;
 
 void filetable_init(void);
-void filetable_addfile(void);
+int filetable_addfile(struct fs_file newfile);
 
 /*
  * Macros to shorten the calling sequences.

--- a/kern/include/fs.h
+++ b/kern/include/fs.h
@@ -30,6 +30,9 @@
 #ifndef _FS_H_
 #define _FS_H_
 
+#include <limits.h>
+#include <types.h>
+
 struct vnode; /* in vnode.h */
 
 
@@ -75,6 +78,39 @@ struct fs_ops {
 	int           (*fsop_getroot)(struct fs *, struct vnode **);
 	int           (*fsop_unmount)(struct fs *);
 };
+
+/*
+* Open file structure:
+*
+*     f_vnode    - vnode in filesystem
+*     f_mode     - file mode (O_WRONLY, O_RDONLY, O_RDWR)
+*     f_offset   - file offset 
+*     f_lock     - lock to protect file in multithreaded scenarios
+*     f_refcount - number of processes that have opened this file
+* Created by open system call. 
+*/
+struct fs_file {
+	struct vnode *f_vnode;
+	unsigned      f_mode;
+	unsigned      f_offset;
+	bool          f_lock;
+	unsigned      f_refcount;
+};
+
+/*
+* Global file system table (extern)
+* It is a double-linked list (DLL)
+*/
+struct fs_filetable {
+	struct fs_file current;
+	struct fs_file *prev;
+	struct fs_file *next;
+};
+
+extern struct fs_filetable sys_filetable;
+
+void filetable_init(void);
+void filetable_addfile(void);
 
 /*
  * Macros to shorten the calling sequences.

--- a/kern/include/fs.h
+++ b/kern/include/fs.h
@@ -84,33 +84,36 @@ struct fs_ops {
 *
 *     f_vnode    - vnode in filesystem
 *     f_mode     - file mode (O_WRONLY, O_RDONLY, O_RDWR)
-*     f_offset   - file offset 
+*     f_offset   - file offset
 *     f_lock     - lock to protect file in multithreaded scenarios
-*     f_refcount - number of processes that have opened this file
-* Created by open system call. 
+*     f_refcount - number of procetable_nodesses that have opened this file
+*     f_next     - pointer to next file
+*     f_prev     - pointer to previous file
+* Created by open system call.
 */
 struct fs_file {
-	struct vnode *f_vnode;
-	unsigned      f_mode;
-	unsigned      f_offset;
-	bool          f_lock;
-	unsigned      f_refcount;
+	struct vnode   *f_vnode;
+	unsigned        f_mode;
+	unsigned        f_offset;
+	bool            f_lock;
+	unsigned        f_refcount;
+	struct fs_file *f_prev;
+	struct fs_file *f_next;
 };
 
 /*
-* Global file system table (extern)
-* It is a double-linked list (DLL)
+* System filetable is a doubly-linked list (DLL).
+* New files get appended at the head.
+* Removed files are freed from the heap.
 */
-struct fs_filetable {
-	struct fs_file current;
-	struct fs_filetable *prev;
-	struct fs_filetable *next;
-};
+extern struct fs_file *sys_filetable_head;
+extern unsigned int sys_filetable_size;
 
-extern struct fs_filetable *sys_filetable;
-
+/* Functions to use the filetable */
 void filetable_init(void);
-int filetable_addfile(struct fs_file newfile);
+int  filetable_addfile(struct fs_file *newfile);
+void filetable_removefile(struct fs_file *rmfile_node);
+unsigned int filetable_size(void);
 
 /*
  * Macros to shorten the calling sequences.

--- a/kern/include/fs.h
+++ b/kern/include/fs.h
@@ -111,7 +111,7 @@ extern unsigned int sys_filetable_size;
 
 /* Functions to use the filetable */
 void filetable_init(void);
-int  filetable_addfile(struct fs_file *newfile);
+void filetable_addfile(struct fs_file *newfile);
 void filetable_removefile(struct fs_file *rmfile_node);
 unsigned int filetable_size(void);
 

--- a/kern/include/proc.h
+++ b/kern/include/proc.h
@@ -37,6 +37,8 @@
  */
 
 #include <spinlock.h>
+#include <limits.h>
+#include <fs.h>
 
 struct addrspace;
 struct thread;
@@ -71,6 +73,7 @@ struct proc {
 	struct vnode *p_cwd;		/* current working directory */
 
 	/* add more material here as needed */
+	struct fs_file *p_filetable[OPEN_MAX];
 };
 
 /* This is the process structure for the kernel and for kernel-only threads. */

--- a/kern/include/proc.h
+++ b/kern/include/proc.h
@@ -73,6 +73,8 @@ struct proc {
 	struct vnode *p_cwd;		/* current working directory */
 
 	/* add more material here as needed */
+
+	/* File descriptor table */
 	struct fs_file *p_filetable[OPEN_MAX];
 };
 

--- a/kern/include/syscall.h
+++ b/kern/include/syscall.h
@@ -57,6 +57,7 @@ __DEAD void enter_new_process(int argc, userptr_t argv, userptr_t env,
  */
 
 int sys_reboot(int code);
+int sys_open(userptr_t filename, int flag, int *retfd);
 int sys___time(userptr_t user_seconds, userptr_t user_nanoseconds);
 
 #endif /* _SYSCALL_H_ */

--- a/kern/main/main.c
+++ b/kern/main/main.c
@@ -112,6 +112,7 @@ boot(void)
 	hardclock_bootstrap();
 	vfs_bootstrap();
 	kheap_nextgeneration();
+	filetable_init();
 
 	/* Probe and initialize devices. Interrupts should come on. */
 	kprintf("Device probe...\n");

--- a/kern/proc/proc.c
+++ b/kern/proc/proc.c
@@ -48,6 +48,7 @@
 #include <current.h>
 #include <addrspace.h>
 #include <vnode.h>
+#include <limits.h>
 
 /*
  * The process for the kernel; this holds all the kernel-only threads.
@@ -62,6 +63,7 @@ struct proc *
 proc_create(const char *name)
 {
 	struct proc *proc;
+	unsigned int fd;
 
 	proc = kmalloc(sizeof(*proc));
 	if (proc == NULL) {
@@ -81,6 +83,10 @@ proc_create(const char *name)
 
 	/* VFS fields */
 	proc->p_cwd = NULL;
+
+	for (fd = 0; fd < OPEN_MAX; fd++) {
+		proc->p_filetable[fd] = NULL;
+	}
 
 	return proc;
 }

--- a/kern/syscall/files_syscalls.c
+++ b/kern/syscall/files_syscalls.c
@@ -50,41 +50,21 @@
  * linker). And you'd have to write a dynamic linker...
  */
 
-#include <fs.h>
-#include <kern/errno.h>
-#include <lib.h>
+#include <types.h>
+#include <copyinout.h>
+#include <syscall.h>
+#include <vfs.h>
+#include <current.h>
+#include <limits.h>
 
-#define FIRST_FILE (sys_filetable->next == NULL && sys_filetable->prev == NULL)
-
-struct fs_filetable *sys_filetable;
-
-void
-filetable_init(void)
-{
-    sys_filetable = (struct fs_filetable *) kmalloc(sizeof(struct fs_filetable)); 
-    if (next_node == NULL) {
-        return ENOMEM;
-    }
-    sys_filetable->next = NULL;
-    sys_filetable->prev = NULL;
-}
-
+/*
+* System call interface function for opening file
+*/
 int
-filetable_addfile(struct fs_file newfile)
+sys_open(userptr_t filename, int flag, int *retfd)
 {
-    if (FIRST_FILE) {
-        sys_filetable->current = newfile;
-    } else {
-        struct fs_filetable *next_node;
-        next_node = (struct fs_filetable *) kmalloc(sizeof(struct fs_filetable));
-        if (next_node == NULL) {
-            return ENOMEM;
-        }
-        next_node->current = newfile;
-        next_node->next = NULL;
-        next_node->prev = sys_filetable;
-        sys_filetable->next = next_node;
-        sys_filetable = next_node;
-    }
+    (void) filename;
+    (void) flag;
+    (void) retfd;
     return 0;
 }

--- a/userland/testbin/Makefile
+++ b/userland/testbin/Makefile
@@ -10,7 +10,7 @@ SUBDIRS=add argtest badcall bigexec bigfile bigfork bigseek bloat conman \
 	filetest forkbomb forktest frack hash hog huge \
 	malloctest matmult multiexec palin parallelvm poisondisk psort \
 	randcall redirect rmdirtest rmtest \
-	sbrktest schedpong sort sparsefile tail tictac triplehuge \
+	sbrktest schedpong sort sparsefile tail testopen tictac triplehuge \
 	triplemat triplesort usemtest zero
 
 # But not:

--- a/userland/testbin/testopen/Makefile
+++ b/userland/testbin/testopen/Makefile
@@ -1,0 +1,10 @@
+# Makefile for tail
+
+TOP=../../..
+.include "$(TOP)/mk/os161.config.mk"
+
+PROG=testopen
+SRCS=testopen.c
+BINDIR=/testbin
+
+.include "$(TOP)/mk/os161.prog.mk"

--- a/userland/testbin/testopen/testopen.c
+++ b/userland/testbin/testopen/testopen.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2000, 2001, 2002, 2003, 2004, 2005, 2008, 2009
+ *	The President and Fellows of Harvard College.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE UNIVERSITY OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * testopen.c
+ *
+ * 	Test program for open syscall.
+ *	Usage: testopen
+ *
+ */
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+int
+main()
+{
+    int fd;
+    fd = open("hello.txt", O_CREAT|O_WRONLY);
+    (void) fd;
+    //printf("File descriptor: %d", fd);
+
+    return 0;
+}


### PR DESCRIPTION
Pull request for open syscall.

In this branch there is:
- fs_file structure that represents an open file
- a doubly-linked list of fs_file that is the global system file table
- the functions to manage the system file table (insert element, remove element)
- the body of the sys_open function called by the open system call

The syscall needs to be tested but since other syscalls are missing most executables do not work so it is difficult to test...