### PR TITLE
Lseek syscall

### DIFF
--- a/kern/arch/mips/syscall/syscall.c
+++ b/kern/arch/mips/syscall/syscall.c
@@ -115,7 +115,7 @@ syscall(struct trapframe *tf)
 				(int) tf->tf_a1,
 				&retval);
 		break;
-    
+
 		case SYS_close:
 		err = sys_close(tf->tf_a0);
     	break;
@@ -131,6 +131,13 @@ syscall(struct trapframe *tf)
 		err = sys_write((int) tf->tf_a0,
 			(userptr_t) tf->tf_a1,
 			(size_t) tf->tf_a2,
+			&retval);
+		break;
+
+		case SYS_lseek:
+		err = sys_lseek((int) tf->tf_a0,
+			(__off_t) tf->tf_a1,
+			(int) tf->tf_a2,
 			&retval);
 		break;
 

--- a/kern/arch/mips/syscall/syscall.c
+++ b/kern/arch/mips/syscall/syscall.c
@@ -82,11 +82,25 @@ syscall(struct trapframe *tf)
 	int32_t retval;
 	int err;
 
+	int *more_args;
+	int64_t first_pair;
+	int64_t second_pair;
+
 	KASSERT(curthread != NULL);
 	KASSERT(curthread->t_curspl == 0);
 	KASSERT(curthread->t_iplhigh_count == 0);
 
 	callno = tf->tf_v0;
+	/*
+	*  if you have more that 4 32-bit args or 2 64-bit args, the other args are
+	*  saved from sp+16
+	*/
+	more_args = (void *) tf->tf_sp + 16;
+	/* in case of 64 bit args consider a0-a1 as a 64 bit arg */
+	first_pair = (((int64_t) tf->tf_a0) << 32) | tf->tf_a1;
+	/* in case of 64 bit args consider a2-a3 as a 64 bit arg */
+	second_pair = (((int64_t) tf->tf_a2) << 32) | tf->tf_a3;
+	(void) first_pair; // REMOVE if you use the first pair somewhere
 
 	/*
 	 * Initialize retval to 0. Many of the system calls don't
@@ -135,9 +149,10 @@ syscall(struct trapframe *tf)
 		break;
 
 		case SYS_lseek:
+		more_args = (int *) more_args;
 		err = sys_lseek((int) tf->tf_a0,
-			(__off_t) tf->tf_a1,
-			(int) tf->tf_a2,
+			(__off_t) second_pair,
+			(int) *more_args,
 			&retval);
 		break;
 

--- a/kern/include/syscall.h
+++ b/kern/include/syscall.h
@@ -61,8 +61,9 @@ int sys_open(userptr_t filename, int flag, int *retfd);
 int sys_close(int fd);
 int sys_read(int fd, userptr_t buf, size_t buflen, int *retval);
 int sys_write(int fd, userptr_t buf, size_t buflen, int *retval);
+int sys_lseek(int fd, __off_t pos, int whence, int *retval);
 int sys___time(userptr_t user_seconds, userptr_t user_nanoseconds);
-int sys_getpid(int *retpid); 
+int sys_getpid(int *retpid);
 int sys__exit(int status);
 
 #endif /* _SYSCALL_H_ */

--- a/kern/syscall/files_syscalls.c
+++ b/kern/syscall/files_syscalls.c
@@ -46,6 +46,7 @@
 #include <kern/errno.h>
 #include <vm.h>
 #include <kern/seek.h>
+#include <kern/stat.h>
 
 /*
 * System call interface function for opening files
@@ -189,7 +190,7 @@ sys_read(int fd, userptr_t buf, size_t buflen, int *retval)
         return err;
     }
 
-    kprintf("Read: %s\n", (char *) buf);
+    //kprintf("Read: %s\n", (char *) buf);
 
     /* give as return value the number of bytes read */
     *retval = userio.uio_offset - openfile->f_offset;
@@ -213,6 +214,7 @@ sys_write(int fd, userptr_t buf, size_t buflen, int *retval)
     userptr_t bufend = buf + buflen;
 
     /* TODO: lock file while writing */
+    /* TODO: copy buffer to kernel space */
 
     /*
     *  bad buffer: either you want to write to null pointer or the buffer is
@@ -270,28 +272,30 @@ int
 sys_lseek(int fd, __off_t pos, int whence, int *retval)
 {
     struct fs_file *openfile;
+    struct stat    fstat;
     int seekpos;
     int seekable;
-    int err, not_eof = 1;
-    struct iovec iov;
-    struct uio kio;
-    char temp_buf;
+    int err;
 
+    /* retrieve file struct from file descriptor and check it is a valid file */
     openfile = curproc->p_filetable[fd];
     if (openfile == NULL) {
         return EBADF;
     }
 
+    /* check if the file is seekable */
     seekable = VOP_ISSEEKABLE(openfile->f_vnode);
     if (seekable == false) {
         return ESPIPE;
     }
 
+    /* execute the appropriate lseek mode depending on whence */
     switch (whence)
     {
     case SEEK_SET:
         seekpos = pos;
-        if (pos < 0) {
+        /* check if the seeking position is positive */
+        if (seekpos < 0) {
             return EINVAL;
         } else {
             openfile->f_offset = seekpos;
@@ -306,16 +310,14 @@ sys_lseek(int fd, __off_t pos, int whence, int *retval)
         }
         break;
     case SEEK_END:
-        uio_kinit(&iov, &kio, &temp_buf, 1, openfile->f_offset, UIO_READ);
-        while (not_eof) {
-            err = VOP_READ(openfile->f_vnode, &kio);
-            if (err) {
-                return err;
-            }
-            not_eof = openfile->f_offset - kio.uio_offset;
-            openfile->f_offset = kio.uio_offset;
+        /* VOP_STAT returns some infos about the file */
+        err = VOP_STAT(openfile->f_vnode, &fstat);
+        if (err) {
+            return err;
         }
-        seekpos = openfile->f_offset + pos;
+        //kprintf("Size: %lld\n", fstat.st_size);
+        /* fstat.st_size contains the size of the file */
+        seekpos = (fstat.st_size - 1) + pos;
 
         if (seekpos < 0) {
             return EINVAL;
@@ -328,6 +330,7 @@ sys_lseek(int fd, __off_t pos, int whence, int *retval)
         break;
     }
 
+    /* return the current seek position */
     *retval = seekpos;
     return 0;
 }

--- a/userland/testbin/Makefile
+++ b/userland/testbin/Makefile
@@ -11,7 +11,7 @@ SUBDIRS=add argtest badcall bigexec bigfile bigfork bigseek bloat conman \
 	malloctest matmult multiexec palin parallelvm poisondisk psort \
 	randcall redirect rmdirtest rmtest \
 	sbrktest schedpong sort sparsefile tail testopen testread testwrite \
-	testexti testgetpid tictac triplehuge triplemat triplesort usemtest zero
+	testexit testlseek testgetpid tictac triplehuge triplemat triplesort usemtest zero
 
 # But not:
 #    userthreads    (no support in kernel API in base system)

--- a/userland/testbin/testlseek/Makefile
+++ b/userland/testbin/testlseek/Makefile
@@ -1,0 +1,10 @@
+# Makefile for testlseek
+
+TOP=../../..
+.include "$(TOP)/mk/os161.config.mk"
+
+PROG=testlseek
+SRCS=testlseek.c
+BINDIR=/testbin
+
+.include "$(TOP)/mk/os161.prog.mk"

--- a/userland/testbin/testlseek/testlseek.c
+++ b/userland/testbin/testlseek/testlseek.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2000, 2001, 2002, 2003, 2004, 2005, 2008, 2009
+ *	The President and Fellows of Harvard College.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE UNIVERSITY OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * testlseek.c
+ *
+ * 	Test program for lseek syscall.
+ *	Usage: testlseek
+ *
+ */
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+int
+main()
+{
+    int fd, bytes;
+    char buffer[5], buffer2[5];
+    fd = open("hello.txt", O_CREAT|O_WRONLY);
+
+    bytes = read(fd, buffer, 5);
+    printf("%s : %d\n", buffer, bytes);
+
+    lseek(fd, -3, SEEK_END);
+    bytes = read(fd, buffer2, 5);
+    printf("%s : %d\n", buffer2, bytes);
+
+    lseek(fd, -1, SEEK_SET);
+    bytes = read(fd, buffer2, 5);
+    printf("%s : %d\n", buffer2, bytes);
+
+    return 0;
+}


### PR DESCRIPTION
This commits adds the work for the lseek syscall.
There is also the code to treat the pair of registers a0,a1 and a2,a3 as 64 bit arguments and the pointer to more arguments in the syscall dispatcher.