### PR TITLE
Files improv

### DIFF
--- a/kern/include/fs.h
+++ b/kern/include/fs.h
@@ -32,6 +32,7 @@
 
 #include <limits.h>
 #include <types.h>
+#include <lib.h>
 #include <kern/fcntl.h>
 #include <kern/unistd.h>
 #include <vfs.h>
@@ -109,16 +110,25 @@ struct fs_file {
 * New files get appended at the head.
 * Removed files are freed from the heap.
 */
-extern struct fs_file *sys_filetable_head;
-extern unsigned int sys_filetable_size;
-extern struct fs_file *stdin, *stdout, *stderr;
+
+struct fs_filetable {
+	struct fs_file *head;
+	struct fs_file *tail;
+	size_t size;
+	struct fs_file *stdin;
+	struct fs_file *stdout;
+	struct fs_file *stderr;
+};
+
+extern struct fs_filetable sys_filetable;
 
 /* Functions to use the filetable */
 int filetable_init(void);
 void filetable_addfile(struct fs_file *newfile);
 void filetable_removefile(struct fs_file *rmfile_node);
-unsigned int filetable_size(void);
-struct fs_file *filetable_gettail(void);
+size_t filetable_size(void);
+struct fs_file *filetable_head(void);
+struct fs_file *filetable_tail(void);
 
 /*
  * Macros to shorten the calling sequences.

--- a/kern/include/lib.h
+++ b/kern/include/lib.h
@@ -194,5 +194,6 @@ void kprintf_bootstrap(void);
 #define DIVROUNDUP(a,b) (((a)+(b)-1)/(b))
 #define ROUNDUP(a,b)    (DIVROUNDUP(a,b)*(b))
 
+int check_buffer(userptr_t buffer, size_t buflen);
 
 #endif /* _LIB_H_ */

--- a/kern/lib/misc.c
+++ b/kern/lib/misc.c
@@ -30,6 +30,7 @@
 #include <types.h>
 #include <kern/errmsg.h>
 #include <lib.h>
+#include <machine/vm.h>
 
 /*
  * Like strdup, but calls kmalloc.
@@ -59,4 +60,20 @@ strerror(int errcode)
 	}
 	panic("Invalid error code %d\n", errcode);
 	return NULL;
+}
+
+/*
+ * Function that checks if a user buffer is valid: does not point to NULL and
+ * is not partially or completely in kernel space
+ */
+
+int
+check_buffer(userptr_t buffer, size_t buflen)
+{
+	userptr_t bufend = buffer + buflen;
+	if (buffer == NULL || bufend >= (userptr_t) USERSPACETOP) {
+		return 1;
+	} else {
+		return 0;
+	}
 }

--- a/kern/main/main.c
+++ b/kern/main/main.c
@@ -95,6 +95,7 @@ boot(void)
 	 * anything at all. You can make it larger though (it's in
 	 * dev/generic/console.c).
 	 */
+	int err;
 
 	kprintf("\n");
 	kprintf("OS/161 base system version %s\n", BASE_VERSION);
@@ -132,7 +133,10 @@ boot(void)
 	vfs_setbootfs("emu0");
 
 	kheap_nextgeneration();
-	filetable_init();
+	err = filetable_init();
+	if (err) {
+		panic("can't create system filetable\n");
+	}
 
 	/*
 	 * Make sure various things aren't screwed up.

--- a/kern/proc/proc.c
+++ b/kern/proc/proc.c
@@ -85,10 +85,12 @@ proc_create(const char *name)
 	/* VFS fields */
 	proc->p_cwd = NULL;
 
-	proc->p_filetable[STDIN_FILENO] = stdin;
-	proc->p_filetable[STDOUT_FILENO] = stdout;
-	proc->p_filetable[STDERR_FILENO] = stderr;
+	/* link stdin, stdout and stderr to file descriptors 0, 1, 2 */
+	proc->p_filetable[STDIN_FILENO] = sys_filetable.stdin;
+	proc->p_filetable[STDOUT_FILENO] = sys_filetable.stdout;
+	proc->p_filetable[STDERR_FILENO] = sys_filetable.stderr;
 
+	/* zero all other entries in file descriptor table */
 	for (fd = STDERR_FILENO + 1; fd < OPEN_MAX; fd++) {
 		proc->p_filetable[fd] = NULL;
 	}

--- a/userland/testbin/testlseek/testlseek.c
+++ b/userland/testbin/testlseek/testlseek.c
@@ -53,9 +53,9 @@ main()
     bytes = read(fd, buffer2, 5);
     printf("%s : %d\n", buffer2, bytes);
 
-    lseek(fd, -1, SEEK_SET);
-    bytes = read(fd, buffer2, 5);
-    printf("%s : %d\n", buffer2, bytes);
-
+    if (lseek(fd, -1, SEEK_SET) > 0) {
+        bytes = read(fd, buffer2, 5);
+        printf("%s : %d\n", buffer2, bytes);
+    }
     return 0;
 }

--- a/userland/testbin/testread/testread.c
+++ b/userland/testbin/testread/testread.c
@@ -52,8 +52,8 @@ main()
         bytes = read(fd, &buffer[i], 1);
         i++;
     }
+    printf("read: %s", buffer);
 
-    (void) bytes;
     close(fd);
     return 0;
 }


### PR DESCRIPTION
Filesystem table was rewritten in a more readable way (with a separate struct). Close syscall decrements refcount of a file and destroys the file only is refcount is equal to zero.
Code refactoring with function to check if a buffer belongs to userspace.