### PR TITLE
Quit bugfix

### DIFF
--- a/kern/proc/proc.c
+++ b/kern/proc/proc.c
@@ -85,11 +85,6 @@ proc_create(const char *name)
 	/* VFS fields */
 	proc->p_cwd = NULL;
 
-	/* link stdin, stdout and stderr to file descriptors 0, 1, 2 */
-	proc->p_filetable[STDIN_FILENO] = sys_filetable.stdin;
-	proc->p_filetable[STDOUT_FILENO] = sys_filetable.stdout;
-	proc->p_filetable[STDERR_FILENO] = sys_filetable.stderr;
-
 	/* zero all other entries in file descriptor table */
 	for (fd = STDERR_FILENO + 1; fd < OPEN_MAX; fd++) {
 		proc->p_filetable[fd] = NULL;
@@ -101,7 +96,7 @@ proc_create(const char *name)
 
 	/* Exit status initialization */
 	proc->p_exit_status = 0;
-	
+
 	return proc;
 }
 

--- a/kern/syscall/runprogram.c
+++ b/kern/syscall/runprogram.c
@@ -97,6 +97,14 @@ runprogram(char *progname)
 		return result;
 	}
 
+	/*
+	* increase the refcount for the stdfiles so that they always have >= 1
+	* refcount and they are not deleted from the sys filetable
+	*/
+	curproc->p_filetable[STDIN_FILENO]->f_refcount++;
+	curproc->p_filetable[STDOUT_FILENO]->f_refcount++;
+	curproc->p_filetable[STDERR_FILENO]->f_refcount++;
+
 	/* Warp to user mode. */
 	enter_new_process(0 /*argc*/, NULL /*userspace addr of argv*/,
 			  NULL /*userspace addr of environment*/,


### PR DESCRIPTION
This fixes a bug when quitting.
The problem was not moving head of the system filetable.

Moreover, more robustness is given by the fact that the stdfiles cannot be removed from sys filetable